### PR TITLE
fix: optional tag-path param

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
     description: 'Values file'
     required: false
     default: 'values.yaml'
+  tag-path:
+    description: 'Tag value property name'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -32,3 +35,4 @@ runs:
     - ${{ inputs.repo }}
     - ${{ inputs.path }}
     - ${{ inputs.values }}
+    - ${{ inputs.tag-path }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,7 @@ TOKEN=${3}
 REPO=${4}
 REPO_PATH=${5}
 VALUES=${6}
+TAG_PATH=${7:-$APP.tag}
 
 echo "Release Mesh app '$APP' ($VERSION) in $REPO"
 echo "using values file $VALUES at $PATH"
@@ -27,7 +28,7 @@ else
 fi
 
 # replace version in values file
-yq write --inplace -- $VALUES $APP.tag $VERSION
+yq write --inplace -- $VALUES $TAG_PATH $VERSION
 
 # commit and push
 git add $VALUES


### PR DESCRIPTION
For instance, use 'tag-path: my.tag' to overwrite the corresponding
value with the current version. Uses the app name and '.tag' as
if the parameter is not set or null.